### PR TITLE
Quiz and flashcards

### DIFF
--- a/backend/agent.py
+++ b/backend/agent.py
@@ -1,10 +1,10 @@
 from pydantic_ai import Agent
 from pydantic_ai.usage import UsageLimits
 import lancedb
-from backend.constants import MODEL
+from backend.constants import MODEL, VECTOR_DB_PATH
 import re
 
-vector_db = lancedb.connect(uri="./vector_db")
+vector_db = lancedb.connect(uri=VECTOR_DB_PATH)
 
 rag_agent = Agent(
     model=MODEL,

--- a/backend/agent.py
+++ b/backend/agent.py
@@ -3,6 +3,8 @@ from pydantic_ai.usage import UsageLimits
 import lancedb
 from backend.constants import MODEL, VECTOR_DB_PATH
 import re
+from backend.data_models import RagResponse
+
 
 vector_db = lancedb.connect(uri=VECTOR_DB_PATH)
 
@@ -18,6 +20,7 @@ You can:
 
 Use the appropriate tool based on the user request.
 """,
+    output_type=RagResponse,
 )
 
 

--- a/backend/agent.py
+++ b/backend/agent.py
@@ -68,3 +68,35 @@ def generate_quiz(user_query: str, k: int = 3) -> str:
     """
 
     return rag_agent.model(prompt)
+
+
+@rag_agent.tool_plain
+def generate_flashcards(user_query: str, k: int = 3) -> str:
+
+    topic = user_query.lower().replace("flashcards", "").strip()
+    if not topic:
+        topic = "machine learning"
+
+    results = vector_db["LectureTranscript"].search(query=topic).limit(k).to_list()
+
+    if not results:
+        return "No relevant content found."
+
+    context = "\n\n".join([doc["content"] for doc in results])
+
+    prompt = f"""
+Create study flashcards based ONLY on this content:
+
+{context}
+
+Format:
+Q: question
+A: short clear answer
+
+Rules:
+- Keep answers concise
+- Focus on key concepts
+- Avoid duplicates
+"""
+
+    return rag_agent.model(prompt)

--- a/backend/agent.py
+++ b/backend/agent.py
@@ -2,17 +2,69 @@ from pydantic_ai import Agent
 from pydantic_ai.usage import UsageLimits
 import lancedb
 from backend.constants import MODEL
+import re
 
 vector_db = lancedb.connect(uri="./vector_db")
 
 rag_agent = Agent(
-    model = MODEL,
-    system_prompt = "You are a expert reader and doing quizes and summarize youtube subtitle files"
+    model=MODEL,
+    system_prompt="""
+You are a helpful learning assistant.
+
+You can:
+- retrieve documents
+- generate quizzes
+- create flashcards
+
+Use the appropriate tool based on the user request.
+""",
 )
 
-@rag_agent.tool_plain 
-def retrieve_documents(query: str, k: int=3) -> str:
-    results = vector_db["articles"].search(query=query).limit(k).to_list()
+
+@rag_agent.tool_plain
+def retrieve_documents(query: str, k: int = 3) -> str:
+    results = vector_db["LectureTranscript"].search(query=query).limit(k).to_list()
 
     if not results:
-        return "no documents found."
+        return "No documents found."
+    return "\n\n".join([doc["content"] for doc in results])
+
+
+@rag_agent.tool_plain
+def generate_quiz(user_query: str, k: int = 3) -> str:
+
+    # 1. Extract number of questions (default = 5)
+    match = re.search(r"\d+", user_query)
+    num_questions = int(match.group()) if match else 5
+
+    # 2. Extract topic
+    topic = user_query.lower().replace("quiz", "").strip()
+    if not topic:
+        topic = "machine learning"  # fallback
+
+    # 3. Retrieve from LanceDB (semantic search works because of embeddings)
+    results = vector_db["LectureTranscript"].search(topic).limit(k).to_list()
+
+    if not results:
+        return "No relevant content found."
+
+    # 4. Combine context
+    context = "\n\n".join([doc["content"] for doc in results])
+
+    # 5. Prompt
+    prompt = f"""
+    You are a helpful teacher.
+
+    Create {num_questions} multiple choice quiz questions based ONLY on the content below.
+
+    Content:
+    {context}
+
+    Requirements:
+    - 4 options per question (A, B, C, D)
+    - Clearly mark the correct answer
+    - Make questions clear and not too long
+    - Avoid repeating the same idea
+    """
+
+    return rag_agent.model(prompt)


### PR DESCRIPTION
## Overview
This PR adds quiz and flashcard generation features using a RAG-based approach.

## Changes
- Added `generate_quiz` tool for multiple-choice question generation
- Added `generate_flashcards` tool for Q/A study cards
- Integrated LanceDB semantic search with LectureTranscript data
- Updated system prompt to support learning-focused tasks
- Fixed retrieve_documents to return actual content

## How to test
- Run the backend with uvicorn
- Send prompts like:
  - "Generate a quiz about LLMs"
  - "Create flashcards about embeddings"