### PR TITLE
feat: Add theme switcher and fix input text color

### DIFF
--- a/src/study_buddy/frontend/app.py
+++ b/src/study_buddy/frontend/app.py
@@ -12,83 +12,78 @@ def get_base64_of_bin_file(bin_file):
         data = f.read()
     return base64.b64encode(data).decode()
 
-def set_background(png_file):
+def set_background(png_file, theme):
     try:
         bin_str = get_base64_of_bin_file(png_file)
-        page_bg_img = f'''
+
+        # Define CSS for both light and dark themes
+        light_theme_css = f'''
         <style>
+        /* General App Style */
         .stApp {{
             background-image: url("data:image/png;base64,{bin_str}");
             background-size: cover;
-            background-attachment: fixed;
-            background-position: center;
         }}
+        /* Main content block with blur effect */
         .block-container {{
             background-color: rgba(255, 255, 255, 0.45);
             backdrop-filter: blur(8px);
-            padding: 2rem 2.5rem 0.5rem 2.5rem !important;
-            border-radius: 20px;
-            margin-top: 2rem;
             border: 1px solid rgba(255, 255, 255, 0.4);
-            box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.2);
         }}
-        .block-container > div:last-child {{ margin-bottom: 0 !important; padding-bottom: 0 !important; }}
-        footer {{ display: none !important; }}
-        .stDeployButton {{ display: none !important; }}
-        #MainMenu {{ visibility: hidden; }}
-        [data-testid="stSidebar"] {{
-            background-color: transparent !important;
-            background-image: none !important;
-        }}[data-testid="stSidebar"] > div:first-child {{
-            background-color: rgba(255, 255, 255, 0.25) !important;
-            backdrop-filter: blur(10px);
-            border-right: 1px solid rgba(255, 255, 255, 0.2);
-        }}
+        /* General text color */
         h1, h2, h3, span, label, p, .stMarkdown p {{
             color: #1E1E1E !important;
-            text-shadow: 0px 0px 10px rgba(255,255,255,0.5);
         }}
-        [data-testid="stSidebar"] li {{
-            color: #1E1E1E !important;
-            font-size: 1.2rem !important;
-            font-weight: 600 !important;
-            margin-bottom: 10px !important;
-        }}
-        div.stButton > button, div.stDownloadButton > button {{
-            background-color: #1E1E1E !important;
-            border-radius: 10px !important;
-            border: 1px solid rgba(255, 255, 255, 0.5) !important;
-            padding: 0.5rem 1rem !important;
-            transition: all 0.3s ease;
-        }}
-        div.stButton > button p, div.stDownloadButton > button p,
-        div.stButton > button span, div.stDownloadButton > button span {{
-            color: #FFFFFF !important;
-            font-weight: 600 !important;
-        }}
-        div.stButton > button:hover, div.stDownloadButton > button:hover {{
-            background-color: #333333 !important;
-            box-shadow: 0 4px 10px rgba(0,0,0,0.3) !important;
-        }}
+        /* Input box styling for light mode */
         div[data-baseweb="input"] {{
-            background-color: #1E1E1E !important;
-            border-radius: 8px !important;
+            background-color: rgba(255, 255, 255, 0.8) !important;
+            border: 1px solid rgba(0, 0, 0, 0.2) !important;
+        }}
+        div[data-baseweb="base-input"] input {{
+            color: #000000 !important;
+            -webkit-text-fill-color: #000000 !important;
+        }}
+        </style>
+        '''
+
+        dark_theme_css = f'''
+        <style>
+        /* General App Style */
+        .stApp {{
+            background-image: url("data:image/png;base64,{bin_str}");
+            background-size: cover;
+        }}
+        /* Main content block with blur effect */
+        .block-container {{
+            background-color: rgba(30, 30, 30, 0.6);
+            backdrop-filter: blur(10px);
+            border: 1px solid rgba(255, 255, 255, 0.2);
+        }}
+        /* General text color */
+        h1, h2, h3, span, label, p, .stMarkdown p {{
+            color: #FFFFFF !important;
+        }}
+        /* Input box styling for dark mode */
+        div[data-baseweb="input"] {{
+            background-color: #2E2E2E !important;
+            border: 1px solid rgba(255,255,255,0.3) !important;
         }}
         div[data-baseweb="base-input"] input {{
             color: #FFFFFF !important;
             -webkit-text-fill-color: #FFFFFF !important;
         }}
-        [data-testid="stExpander"] summary {{
-            background-color: #1E1E1E !important;
-            border-radius: 8px !important;
-            padding: 0.5rem 1rem !important;
-        }}[data-testid="stExpander"] summary p, [data-testid="stExpander"] summary span {{
-            color: #FFFFFF !important;
-            font-weight: 600 !important;
-        }}
         </style>
         '''
-        st.markdown(page_bg_img, unsafe_allow_html=True)
+
+        # Select and apply the theme's CSS
+        if theme == 'dark':
+            st.markdown(dark_theme_css, unsafe_allow_html=True)
+        else:
+            st.markdown(light_theme_css, unsafe_allow_html=True)
+
+        # Apply any other common CSS here if you refactor it out
+        # For simplicity, common styles are duplicated in the strings above
+
     except FileNotFoundError:
         st.warning("Background image 'background.jpg' not found.")
 
@@ -104,11 +99,33 @@ def create_pdf(text, title="Study Material"):
     return pdf.output(dest="S").encode("latin-1")
 
 def layout():
+
     st.set_page_config(page_title="Study Buddy", page_icon="🎓", layout="centered")
-    set_background("background.jpg")
+
+    if 'theme' not in st.session_state:
+        st.session_state.theme = 'light'  # Default to light mode
+
+    set_background("background.jpg", st.session_state.theme)
 
     with st.sidebar:
         st.title("🎓 Study Tools")
+        if st.session_state.theme == 'light':
+            if st.button('🌙 Switch to Dark Mode'):
+                st.session_state.theme = 'dark'
+                st.rerun() # Use st.rerun() for newer Streamlit versions
+        else:
+            if st.button('☀️ Switch to Light Mode'):
+                st.session_state.theme = 'light'
+                st.rerun() # Use st.rerun() for newer Streamlit versions
+
+        st.markdown("---") # Optional: adds a divider
+        # --- END OF ADDED CODE BLOCK ---
+
+        st.markdown("""
+        **Subjects you can ask about:**
+        - Python
+        ...
+        """)
         st.markdown("""
         **Subjects you can ask about:**
         - Python

--- a/uv.lock
+++ b/uv.lock
@@ -988,16 +988,24 @@ wheels = [
 ]
 
 [[package]]
+name = "fpdf"
+version = "1.7.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/c6/608a9e6c172bf9124aa687ec8b9f0e8e5d697d59a5f4fad0e2d5ec2a7556/fpdf-1.7.2.tar.gz", hash = "sha256:125840783289e7d12552b1e86ab692c37322e7a65b96a99e0ea86cca041b6779", size = 39504, upload-time = "2015-01-21T00:07:47.493Z" }
+
+[[package]]
 name = "frontend"
 version = "0.1.0"
 source = { editable = "src/study_buddy/frontend" }
 dependencies = [
+    { name = "fpdf" },
     { name = "httpx" },
     { name = "streamlit" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "fpdf" },
     { name = "httpx" },
     { name = "streamlit" },
 ]
@@ -1217,7 +1225,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/58/fc576f99037ce19c5aa16628e4c3226b6d1419f72a62c79f5f40576e6eb3/greenlet-3.5.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:5a5ed18de6a0f6cc7087f1563f6bd93fc7df1c19165ca01e9bde5a5dc281d106", size = 285066, upload-time = "2026-04-27T12:23:05.033Z" },
     { url = "https://files.pythonhosted.org/packages/4a/ba/b28ddbe6bfad6a8ac196ef0e8cff37bc65b79735995b9e410923fffeeb70/greenlet-3.5.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a717fbc46d8a354fa675f7c1e813485b6ba3885f9bef0cd56e5ba27d758ff5b", size = 604414, upload-time = "2026-04-27T12:52:42.358Z" },
     { url = "https://files.pythonhosted.org/packages/09/06/4b69f8f0b67603a8be2790e55107a190b376f2627fe0eaf5695d85ffb3cd/greenlet-3.5.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ddc090c5c1792b10246a78e8c2163ebbe04cf877f9d785c230a7b27b39ad038e", size = 617349, upload-time = "2026-04-27T12:59:43.32Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/15/a643b4ecd09969e30b8a150d5919960caae0abe4f5af75ab040b1ab85e78/greenlet-3.5.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4964101b8585c144cbda5532b1aa644255126c08a265dae90c16e7a0e63aaa9d", size = 623234, upload-time = "2026-04-27T13:02:40.611Z" },
     { url = "https://files.pythonhosted.org/packages/8a/17/a3918541fd0ddefe024a69de6d16aa7b46d36ac19562adaa63c7fa180eff/greenlet-3.5.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2094acd54b272cb6eae8c03dd87b3fa1820a4cef18d6889c378d503500a1dc13", size = 613927, upload-time = "2026-04-27T12:25:30.28Z" },
+    { url = "https://files.pythonhosted.org/packages/77/18/3b13d5ef1275b0ffaf933b05efa21408ac4ca95823c7411d79682e4fdcff/greenlet-3.5.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:7022615368890680e67b9965d33f5773aade330d5343bbe25560135aaa849eae", size = 425243, upload-time = "2026-04-27T13:05:15.689Z" },
     { url = "https://files.pythonhosted.org/packages/ee/e1/bd0af6213c7dd33175d8a462d4c1fe1175124ebed4855bc1475a5b5242c2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5e05ba267789ea87b5a155cf0e810b1ab88bf18e9e8740813945ceb8ee4350ba", size = 1570893, upload-time = "2026-04-27T12:53:29.483Z" },
     { url = "https://files.pythonhosted.org/packages/9b/2a/0789702f864f5382cb476b93d7a9c823c10472658102ccd65f415747d2e2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0ecec963079cd58cbd14723582384f11f166fd58883c15dcbfb342e0bc9b5846", size = 1636060, upload-time = "2026-04-27T12:25:28.845Z" },
     { url = "https://files.pythonhosted.org/packages/b2/8f/22bf9df92bbff0eb07842b60f7e63bf7675a9742df628437a9f02d09137f/greenlet-3.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:728d9667d8f2f586644b748dbd9bb67e50d6a9381767d1357714ea6825bb3bf5", size = 238740, upload-time = "2026-04-27T12:24:01.341Z" },
@@ -1225,7 +1235,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/94/5e/a70f31e3e8d961c4ce589c15b28e4225d63704e431a23932a3808cbcc867/greenlet-3.5.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:f35807464c4c58c55f0d31dfa83c541a5615d825c2fe3d2b95360cf7c4e3c0a8", size = 285564, upload-time = "2026-04-27T12:23:08.555Z" },
     { url = "https://files.pythonhosted.org/packages/af/a6/046c0a28e21833e4086918218cfb3d8bed51c075a1b700f20b9d7861c0f4/greenlet-3.5.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55fa7ea52771be44af0de27d8b80c02cd18c2c3cddde6c847ecebdf72418b6a1", size = 651166, upload-time = "2026-04-27T12:52:43.644Z" },
     { url = "https://files.pythonhosted.org/packages/47/f8/4af27f71c5ff32a7fbc516adb46370d9c4ae2bc7bd3dc7d066ac542b4b15/greenlet-3.5.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a97e4821aa710603f94de0da25f25096454d78ffdace5dc77f3a006bc01abba3", size = 663792, upload-time = "2026-04-27T12:59:44.93Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/89/2dadb89793c37ee8b4c237857188293e9060dc085f19845c292e00f8e091/greenlet-3.5.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bf2d8a80bec89ab46221ae45c5373d5ba0bd36c19aa8508e85c6cd7e5106cd37", size = 668086, upload-time = "2026-04-27T13:02:42.314Z" },
     { url = "https://files.pythonhosted.org/packages/a3/59/1bd6d7428d6ed9106efbb8c52310c60fd04f6672490f452aeaa3829aa436/greenlet-3.5.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f52a464e4ed91780bdfbbdd2b97197f3accaa629b98c200f4dffada759f3ae7", size = 660933, upload-time = "2026-04-27T12:25:33.276Z" },
+    { url = "https://files.pythonhosted.org/packages/82/35/75722be7e26a2af4cbd2dc35b0ed382dacf9394b7e75551f76ed1abe87f2/greenlet-3.5.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:1bae92a1dd94c5f9d9493c3a212dd874c202442047cf96446412c862feca83a2", size = 470799, upload-time = "2026-04-27T13:05:17.094Z" },
     { url = "https://files.pythonhosted.org/packages/83/e4/b903e5a5fae1e8a28cdd32a0cfbfd560b668c25b692f67768822ddc5f40f/greenlet-3.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:762612baf1161ccb8437c0161c668a688223cba28e1bf038f4eb47b13e39ccdf", size = 1618401, upload-time = "2026-04-27T12:53:31.062Z" },
     { url = "https://files.pythonhosted.org/packages/0e/e3/5ec408a329acb854fb607a122e1ee5fb3ff649f9a97952948a90803c0d8e/greenlet-3.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:57a43c6079a89713522bc4bcb9f75070ecf5d3dbad7792bfe42239362cbf2a16", size = 1682038, upload-time = "2026-04-27T12:25:31.838Z" },
     { url = "https://files.pythonhosted.org/packages/91/20/6b165108058767ee643c55c5c4904d591a830ee2b3c7dbd359828fbc829f/greenlet-3.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:3bc59be3945ae9750b9e7d45067d01ae3fe90ea5f9ade99239dabdd6e28a5033", size = 239835, upload-time = "2026-04-27T12:24:54.136Z" },
@@ -1233,7 +1245,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/78/a8/4522939255bb5409af4e87132f915446bf3622c2c292d14d3c38d128ae82/greenlet-3.5.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:a10a732421ab4fec934783ce3e54763470d0181db6e3468f9103a275c3ed1853", size = 293614, upload-time = "2026-04-27T12:24:12.874Z" },
     { url = "https://files.pythonhosted.org/packages/15/5e/8744c52e2c027b5a8772a01561934c8835f869733e101f62075c60430340/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fc391b1566f2907d17aaebe78f8855dc45675159a775fcf9e61f8ee0078e87f", size = 650723, upload-time = "2026-04-27T12:52:45.412Z" },
     { url = "https://files.pythonhosted.org/packages/00/ef/7b4c39c03cf46ceca512c5d3f914afd85aa30b2cc9a93015b0dd73e4be6c/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:680bd0e7ad5e8daa8a4aa89f68fd6adc834b8a8036dc256533f7e08f4a4b01f7", size = 656529, upload-time = "2026-04-27T12:59:46.295Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/5c/0602239503b124b70e39355cbdb39361ecfe65b87a5f2f63752c32f5286f/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1aa4ce8debcd4ea7fb2e150f3036588c41493d1d52c43538924ae1819003f4ce", size = 657015, upload-time = "2026-04-27T13:02:43.973Z" },
     { url = "https://files.pythonhosted.org/packages/0b/b5/c7768f352f5c010f92064d0063f987e7dc0cd290a6d92a34109015ce4aa1/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddb36c7d6c9c0a65f18c7258634e0c416c6ab59caac8c987b96f80c2ebda0112", size = 654364, upload-time = "2026-04-27T12:25:35.64Z" },
+    { url = "https://files.pythonhosted.org/packages/38/51/8699f865f125dc952384cb432b0f7138aa4d8f2969a7d12d0df5b94d054d/greenlet-3.5.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:728a73687e39ae9ca34e4694cbf2f049d3fbc7174639468d0f67200a97d8f9e2", size = 488275, upload-time = "2026-04-27T13:05:18.28Z" },
     { url = "https://files.pythonhosted.org/packages/ef/d0/079ebe12e4b1fc758857ce5be1a5e73f06870f2101e52611d1e71925ce54/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e5ddf316ced87539144621453c3aef229575825fe60c604e62bedc4003f372b2", size = 1614204, upload-time = "2026-04-27T12:53:32.618Z" },
     { url = "https://files.pythonhosted.org/packages/6d/89/6c2fb63df3596552d20e58fb4d96669243388cf680cff222758812c7bfaa/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4a448128607be0de65342dc9b31be7f948ef4cc0bc8832069350abefd310a8f2", size = 1675480, upload-time = "2026-04-27T12:25:34.168Z" },
     { url = "https://files.pythonhosted.org/packages/15/32/77ee8a6c1564fc345a491a4e85b3bf360e4cf26eac98c4532d2fdb96e01f/greenlet-3.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d60097128cb0a1cab9ea541186ea13cd7b847b8449a7787c2e2350da0cb82d86", size = 245324, upload-time = "2026-04-27T12:24:40.295Z" },


### PR DESCRIPTION
This PR adds a light/dark mode toggle to the sidebar and fixes the bug where input text was invisible in light mode.
- Changes:
Added a theme toggle button using st.session_state.
Corrected CSS for the text input field in both themes.
Added fpdf dependency for PDF downloads and updated uv.lock.
- To Test:
Run the app and use the sidebar button to switch themes.
Confirm the input text color is correct in both modes.